### PR TITLE
Update contribution graph theme to github-dark

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,7 +78,7 @@ I'm the founder of [Big Brain Coding](https://bigbraincoding.com), a web develop
 
 <div align="center">
   <a href="https://github.com/bryanwills">
-    <img width="100%" src="https://github-readme-activity-graph.vercel.app/graph?username=bryanwills&theme=radical&hide_border=true" alt="Bryan's Contribution Graph" />
+    <img width="100%" src="https://github-readme-activity-graph.vercel.app/graph?username=bryanwills&theme=github-dark&hide_border=true" alt="Bryan's Contribution Graph" />
   </a>
 </div>
 


### PR DESCRIPTION
This PR updates the contribution graph theme from radical to github-dark for better visual consistency with GitHub's dark theme.

Changes:
- Changed contribution graph theme from 'radical' to 'github-dark'
- Improves visual consistency with other GitHub elements
- Removes red tint and provides proper dark background